### PR TITLE
Simplified it even further...

### DIFF
--- a/ConsoleTest/ConsoleTest.csproj
+++ b/ConsoleTest/ConsoleTest.csproj
@@ -10,12 +10,13 @@
     <ItemGroup>
       <Analyzer Include="../Generators/bin/Debug/netstandard2.0/Generators.dll" />
     </ItemGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\Generators\Generators.csproj" />
     </ItemGroup>
+    
     <ItemGroup>
       <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.6.0-3.final" />
-      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Generators/Generators.csproj
+++ b/Generators/Generators.csproj
@@ -12,8 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0-3.20207.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0-beta2.final" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.6.0-3.final" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@khalidabuhakmeh. The `<ProjectReference>` doesn't appear to be strictly necessary, it's only for controlling build order AFAICT. If you remove it, then running `dotnet build` twice also works..