### PR TITLE
Simplify ProjectReference to analyzer

### DIFF
--- a/ConsoleTest/ConsoleTest.csproj
+++ b/ConsoleTest/ConsoleTest.csproj
@@ -8,11 +8,9 @@
 
     <!-- Add this as a new ItemGroup, replacing paths and names appropriately -->
     <ItemGroup>
-      <Analyzer Include="../Generators/bin/Debug/netstandard2.0/Generators.dll" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\Generators\Generators.csproj" />
+      <ProjectReference Include="..\Generators\Generators.csproj"  
+          OutputItemType="Analyzer"
+          ReferenceOutputAssembly="false" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Use a `ProjectReference` that doesn't add a code reference
(`ReferenceOutputAssembly="false"`) and specifies that the project's
output should be added to the analyzer items
(`OutputItemType="Analyzer"`) instead of manually referencing the path
to the output assembly in a distinct Analyzer item.

Taken from https://github.com/loic-sharma/InterfaceGenerator/pull/1